### PR TITLE
added general exception to aux.ml

### DIFF
--- a/Comp5310_teaching_version/aux.ml
+++ b/Comp5310_teaching_version/aux.ml
@@ -47,6 +47,8 @@ let callAbella command =
         lines := input_line in_channel :: !lines
       done;
     with End_of_file ->
+      ignore (Unix.close_process_in in_channel) | 
+         _ ->
       ignore (Unix.close_process_in in_channel)
   end;
   List.rev !lines

--- a/aux.ml
+++ b/aux.ml
@@ -47,6 +47,8 @@ let callAbella command =
         lines := input_line in_channel :: !lines
       done;
     with End_of_file ->
+      ignore (Unix.close_process_in in_channel) | 
+         _ ->
       ignore (Unix.close_process_in in_channel)
   end;
   List.rev !lines


### PR DESCRIPTION
Added a general exception to aux.ml to handle the following batteries IO runtime error:
`Fatal error: exception BatInnerIO.Input_closed`
`Fatal error in uncaught exception handler: exception BatInnerIO.Output_closed`